### PR TITLE
`getComputedAttribute` is deprecated. Use `getAttribute` instead

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -78,7 +78,7 @@ AFRAME.registerComponent('force-pushable', {
   forcePush: function () {
     var force,
         el = this.el,
-        pStart = this.pStart.copy(this.sourceEl.getComputedAttribute('position'));
+        pStart = this.pStart.copy(this.sourceEl.getAttribute('position'));
 
     // Compute direction of force, normalize, then scale.
     force = el.body.position.vsub(pStart);
@@ -127,7 +127,7 @@ AFRAME.registerComponent('force-float', {
 
       // Lift targets slightly.
       targets = [].slice.call(targets).forEach(function (el) {
-        var position = new CANNON.Vec3().copy(el.getComputedAttribute('position')),
+        var position = new CANNON.Vec3().copy(el.getAttribute('position')),
             impulse = new CANNON.Vec3(
               0.25 * data.force * Math.random(),
               1.00 * data.force * Math.random() + 1.5,

--- a/src/components/body/body.js
+++ b/src/components/body/body.js
@@ -32,7 +32,7 @@ module.exports = {
     var shape,
         el = this.el,
         data = this.data,
-        pos = el.getComputedAttribute('position'),
+        pos = el.getAttribute('position'),
         options = data.shape === 'auto' ? undefined : AFRAME.utils.extend({}, this.data, {
           type: mesh2shape.Type[data.shape.toUpperCase()]
         });
@@ -60,7 +60,7 @@ module.exports = {
     this.body.addShape(shape, shape.offset, shape.orientation);
 
     // Apply rotation
-    var rot = el.getComputedAttribute('rotation');
+    var rot = el.getAttribute('rotation');
     this.body.quaternion.setFromEuler(
       THREE.Math.degToRad(rot.x),
       THREE.Math.degToRad(rot.y),
@@ -194,7 +194,7 @@ module.exports = {
 
       if (!body) return;
 
-      if (el.components.velocity) body.velocity.copy(el.getComputedAttribute('velocity'));
+      if (el.components.velocity) body.velocity.copy(el.getAttribute('velocity'));
 
       if (parentEl.isScene) {
         body.quaternion.copy(el.object3D.quaternion);

--- a/tests/math/velocity.test.js
+++ b/tests/math/velocity.test.js
@@ -18,14 +18,14 @@ suite('velocity', function () {
 
     test('defaults to 0 0 0', function () {
       component.update();
-      expect(el.getComputedAttribute('velocity')).to.shallowDeepEqual({x: 0, y: 0, z: 0});
+      expect(el.getAttribute('velocity')).to.shallowDeepEqual({x: 0, y: 0, z: 0});
     });
 
     test('updates position', function () {
       el.setAttribute('velocity', {x: 1, y: 2, z: 3});
       delete component.system;
       component.tick(100, 0.1);
-      var position = el.getComputedAttribute('position');
+      var position = el.getAttribute('position');
       expect(position.x).to.be.closeTo(0.0001, EPS);
       expect(position.y).to.be.closeTo(0.0002, EPS);
       expect(position.z).to.be.closeTo(0.0003, EPS);
@@ -70,15 +70,15 @@ suite('velocity', function () {
 
     test('defaults to 0 0 0', function () {
       component.update();
-      expect(el.getComputedAttribute('position')).to.shallowDeepEqual({x: 0, y: 0, z: 0});
+      expect(el.getAttribute('position')).to.shallowDeepEqual({x: 0, y: 0, z: 0});
     });
 
     test('updates position', function () {
       el.setAttribute('velocity', {x: 1, y: 2, z: 3});
       component.tick(100, 0.1);
-      expect(el.getComputedAttribute('position')).to.shallowDeepEqual({x: 0, y: 0, z: 0});
+      expect(el.getAttribute('position')).to.shallowDeepEqual({x: 0, y: 0, z: 0});
       component.step(100, 0.1 /* overridden by maxInterval */);
-      var position = el.getComputedAttribute('position');
+      var position = el.getAttribute('position');
       expect(position.x).to.be.closeTo(0.00005, EPS);
       expect(position.y).to.be.closeTo(0.00010, EPS);
       expect(position.z).to.be.closeTo(0.00015, EPS);


### PR DESCRIPTION
Latest aframe (`master`) deprecated `getComputedAttribute`,
and replaced it with the more intuitive `getAttribute`.

I'm curious about if [this note](https://github.com/donmccurdy/aframe-physics-system/blob/master/src/components/math/velocity.js#L32) has been fixed in aframe@0.4.0?

More info: https://github.com/aframevr/aframe/pull/1925