### PR TITLE
Update to A-Frame v0.5.0

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -148,7 +148,7 @@ AFRAME.registerComponent('force-float', {
       <a-entity camera
                 look-controls
                 position="0 1.764 0">
-        <a-entity cursor="maxDistance: 75"
+        <a-entity cursor raycaster="far: 75"
                   position="0 0 -1"
                   geometry="primitive: circle; radius: 0.01; segments: 4;"
                   material="color: #FF4444; shader: flat"></a-entity>

--- a/examples/index.html
+++ b/examples/index.html
@@ -4,7 +4,7 @@
     <meta http-equiv="content-type" content="text/html; charset=utf-8">
     <meta name="viewport" content="width=device-width,initial-scale=1,shrink-to-fit=no,user-scalable=no,maximum-scale=1">
     <title>Examples • Force Push</title>
-    <script src="https://aframe.io/releases/0.4.0/aframe.min.js"></script>
+    <script src="https://aframe.io/releases/0.5.0/aframe.min.js"></script>
     <script src="bundle.js"></script>
     <script>
 /**

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "aframe": "^0.5.0"
   },
   "devDependencies": {
-    "aframe": "^0.4.0",
+    "aframe": "^0.5.0",
     "browserify": "^13.1.0",
     "budo": "^9.2.1",
     "chai": "^3.5.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "three-to-cannon": "^1.0.4"
   },
   "peerDependencies": {
-    "aframe": "^0.4.0"
+    "aframe": "^0.5.0"
   },
   "devDependencies": {
     "aframe": "^0.4.0",


### PR DESCRIPTION
No anticipated issues based on the A-Frame changelog. Tests pass and example works without any errors or warnings (Nightly and Chromium). 

Would you mind doing a release with the updated version? My packages that depend on this won't build with A-Frame v0.5.0 because of the peer dependency conflict. 

Thanks