### PR TITLE
Bodies without collision geometry

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,14 +50,14 @@ The `dynamic-body` and `static-body` components may be added to any `<a-entity/>
 - **dynamic-body**: A freely-moving object. Dynamic bodies have mass, collide with other objects, bounce or slow during collisions, and fall if gravity is enabled.
 - **static-body**: A fixed-position or animated object. Other objects may collide with static bodies, but static bodies themselves are unaffected by gravity and collisions.
 
-| Property       | Dependencies     | Default | Description                                 |
-|----------------|------------------|---------|---------------------------------------------|
-| shape          | —                | `auto`  | `auto`, `box`, `cylinder`, `sphere`, `hull` |
-| mass           | `dynamic-body`   | 5       | Simulated mass of the object, > 0.          |
-| linearDamping  | `dynamic-body`   | 0.01    | Resistance to movement.                     |
-| angularDamping | `dynamic-body`   | 0.01    | Resistance to rotation.                     |
-| sphereRadius   |  `shape:sphere`  | —       | Override default radius of bounding sphere. |
-| cylinderAxis   | `shape:cylinder` | —       | Override default axis of bounding cylinder. |
+| Property       | Dependencies     | Default | Description                                         |
+|----------------|------------------|---------|-----------------------------------------------------|
+| shape          | —                | `auto`  | `auto`, `box`, `cylinder`, `sphere`, `hull`, `none` |
+| mass           | `dynamic-body`   | 5       | Simulated mass of the object, > 0.                  |
+| linearDamping  | `dynamic-body`   | 0.01    | Resistance to movement.                             |
+| angularDamping | `dynamic-body`   | 0.01    | Resistance to rotation.                             |
+| sphereRadius   |  `shape:sphere`  | —       | Override default radius of bounding sphere.         |
+| cylinderAxis   | `shape:cylinder` | —       | Override default axis of bounding cylinder.         |
 
 ### Basics
 
@@ -134,6 +134,7 @@ Body components will attempt to find an appropriate CANNON.js shape to fit your 
 * **Primitives** – Plane/Cylinder/Sphere. Used automatically with the corresponding A-Frame primitives.
 * **Trimesh** – *Deprecated.* Not available as a custom shape, but may be chosen as a last resort for custom geometry. Trimeshes adapt to fit custom geometry (e.g. a `.OBJ` or `.DAE` file), but have very minimal support. Arbitrary trimesh shapes are difficult to model in any JS physics engine, will "fall through" certain other shapes, and have serious performance limitations.
 * **Compound** – *In progress.* Compound shapes require a bit of work to set up, but allow you to use multiple primitives to define a physics shape around custom models. These will generally perform better, and behave more accurately, than Trimesh or Convex shapes. For example, a stool might be modeled as a cylinder-shaped seat, on four long cylindrical legs.
+* **None** (`none`) – Does not add collision geometry.
 
 For more details, see the CANNON.js [collision matrix](https://github.com/schteppe/cannon.js#features).
 

--- a/src/components/body/body.js
+++ b/src/components/body/body.js
@@ -49,11 +49,6 @@ module.exports = {
     // Potential fix: https://github.com/mrdoob/three.js/pull/7019
     this.el.object3D.updateMatrixWorld(true);
 
-    // There are some cases where collision geometry is not desirable
-    // One use case is using a lock constraint of a dynamic body to a hand-controls object
-    // The hand controls can't directly reconcile being a dynamic object with being directly positioned
-    // The lock constraint has a limit on the force that it will apply to enforce the constraint
-    // This prevents the locked object from clipping through static geometry.
     if(data.shape !== 'none') {
       var options = data.shape === 'auto' ? undefined : AFRAME.utils.extend({}, this.data, {
         type: mesh2shape.Type[data.shape.toUpperCase()]


### PR DESCRIPTION
This pull request adds functionality to create a body attached to an entity without adding a shape to that body. The resulting body still has position and orientation which means it can still be used with constraints. To create a body without collision geometry use `none` as the shape parameter in this modification.

There are some tricks that can be done with bodies that don't have collision geometry.

My particular use and reason for creating this modification was to create hand controls that can't go through walls. Making hand controls themselves dynamic bodies did not work as the physics system just overwrote the position gathered from the sensors. Hand controls as static bodies are essentially unstoppable and go through walls without flinching.

I made hand controls that respond to physics by making the actual hand controls an invisible static-body entity without collision geometry and constraining a dynamic-body to the hand controls to be the representation of the hands in VR instead. It is not desirable in this case for the hand controls static body to be able to interact with anything in the scene except the dynamic body they're constrained to.