### PR TITLE
improved: physics component update control

### DIFF
--- a/src/components/body/body.js
+++ b/src/components/body/body.js
@@ -97,7 +97,7 @@ module.exports = {
    */
   _play: function () {
     this.syncToPhysics();
-    this.system.addBehavior(this, this.system.Phase.SIMULATE);
+    this.system.addComponent(this);
     this.system.addBody(this.body);
     if (this.wireframe) this.el.sceneEl.object3D.add(this.wireframe);
   },
@@ -108,7 +108,7 @@ module.exports = {
   pause: function () {
     if (!this.isLoaded) return;
 
-    this.system.removeBehavior(this, this.system.Phase.SIMULATE);
+    this.system.removeComponent(this);
     this.system.removeBody(this.body);
     if (this.wireframe) this.el.sceneEl.object3D.remove(this.wireframe);
   },

--- a/src/components/body/dynamic-body.js
+++ b/src/components/body/dynamic-body.js
@@ -14,9 +14,11 @@ var DynamicBody = AFRAME.utils.extend({}, Body, {
     angularDamping: { default: 0.01 }
   }),
 
-  step: function () {
+  updateAfter: function () {
     this.syncFromPhysics();
-  }
+  },
+
+  updateRender: null
 });
 
 module.exports = AFRAME.registerComponent('dynamic-body', DynamicBody);

--- a/src/components/body/static-body.js
+++ b/src/components/body/static-body.js
@@ -7,7 +7,7 @@ var Body = require('./body');
  * other objects may collide with it.
  */
 var StaticBody = AFRAME.utils.extend({}, Body, {
-  step: function () {
+  updateBefore: function () {
     this.syncToPhysics();
   }
 });

--- a/src/components/math/velocity.js
+++ b/src/components/math/velocity.js
@@ -8,23 +8,25 @@ module.exports = AFRAME.registerComponent('velocity', {
     this.system = this.el.sceneEl.systems.physics;
 
     if (this.system) {
-      this.system.addBehavior(this, this.system.Phase.RENDER);
+      this.system.addComponent(this);
     }
   },
 
   remove: function () {
     if (this.system) {
-      this.system.removeBehavior(this, this.system.Phase.RENDER);
+      this.system.removeComponent(this);
     }
   },
 
   tick: function (t, dt) {
     if (!dt) return;
     if (this.system) return;
-    this.step(t, dt);
+    if (this.updateRender) {
+      this.updateRender(t, dt);
+    }
   },
 
-  step: function (t, dt) {
+  updateRender: function (t, dt) {
     if (!dt) return;
 
     var physics = this.el.sceneEl.systems.physics || {data: {maxInterval: 1 / 60}},

--- a/src/system.js
+++ b/src/system.js
@@ -40,15 +40,6 @@ module.exports = AFRAME.registerSystem('physics', {
   },
 
   /**
-   * Update phases, used to separate physics simulation from updates to A-Frame scene.
-   * @enum {string}
-   */
-  Phase: {
-    SIMULATE: 'sim',
-    RENDER:   'render'
-  },
-
-  /**
    * Initializes the physics system.
    */
   init: function () {
@@ -57,9 +48,9 @@ module.exports = AFRAME.registerSystem('physics', {
     // If true, show wireframes around physics bodies.
     this.debug = data.debug;
 
-    this.children = {};
-    this.children[this.Phase.SIMULATE] = [];
-    this.children[this.Phase.RENDER] = [];
+    this.childrenUpdateBefore = [];
+    this.childrenUpdateAfter = [];
+    this.childrenUpdateRender = [];
 
     this.listeners = {};
 
@@ -116,15 +107,19 @@ module.exports = AFRAME.registerSystem('physics', {
   tick: function (t, dt) {
     if (!dt) return;
 
-    this.driver.step(Math.min(dt / 1000, this.data.maxInterval));
-
     var i;
-    for (i = 0; i < this.children[this.Phase.SIMULATE].length; i++) {
-      this.children[this.Phase.SIMULATE][i].step(t, dt);
+    for (i = 0; i < this.childrenUpdateBefore.length; i++) {
+      this.childrenUpdateBefore[i].updateBefore(t, dt);
     }
 
-    for (i = 0; i < this.children[this.Phase.RENDER].length; i++) {
-      this.children[this.Phase.RENDER][i].step(t, dt);
+    this.driver.step(Math.min(dt / 1000, this.data.maxInterval));
+
+    for (i = 0; i < this.childrenUpdateAfter.length; i++) {
+      this.childrenUpdateAfter[i].updateAfter(t, dt);
+    }
+
+    for (i = 0; i < this.childrenUpdateRender.length; i++) {
+      this.childrenUpdateRender[i].updateRender(t, dt);
     }
   },
 
@@ -192,13 +187,21 @@ module.exports = AFRAME.registerSystem('physics', {
   },
 
   /**
-   * Adds a component instance to the system, to be invoked on each tick during
+   * Adds a component instance to the system and schedules its update methods to be called
    * the given phase.
    * @param {Component} component
    * @param {string} phase
    */
-  addBehavior: function (component, phase) {
-    this.children[phase].push(component);
+  addComponent: function (component) {
+    if (component.updateBefore) {
+      this.childrenUpdateBefore.push(component);
+    }
+    if (component.updateAfter) {
+      this.childrenUpdateAfter.push(component);
+    }
+    if (component.updateRender) {
+      this.childrenUpdateRender.push(component);
+    }
   },
 
   /**
@@ -206,8 +209,16 @@ module.exports = AFRAME.registerSystem('physics', {
    * @param {Component} component
    * @param {string} phase
    */
-  removeBehavior: function (component, phase) {
-    this.children[phase].splice(this.children[phase].indexOf(component), 1);
+  removeComponent: function (component) {
+    if (component.updateBefore) {
+      this.childrenUpdateBefore.splice(this.childrenUpdateBefore.indexOf(component), 1);
+    }
+    if (component.updateAfter) {
+      this.childrenUpdateAfter.splice(this.childrenUpdateAfter.indexOf(component), 1);
+    }
+    if (component.updateRender) {
+      this.childrenUpdateRender.splice(this.childrenUpdateRender.indexOf(component), 1);
+    }
   },
 
   /** @return {Array<object>} */

--- a/tests/math/velocity.test.js
+++ b/tests/math/velocity.test.js
@@ -37,16 +37,15 @@ suite('velocity', function () {
         component,
         physics = {
           data: {maxInterval: 0.00005},
-          Phase: {SIMULATE: 0, RENDER: 1},
-          addBehavior: function () {},
-          removeBehavior: function () {}
+          addComponent: function () {},
+          removeComponent: function () {}
         };
 
     setup(function (done) {
       el = this.el = entityFactory();
       el.sceneEl.systems.physics = physics;
-      sinon.spy(physics, 'addBehavior');
-      sinon.spy(physics, 'removeBehavior');
+      sinon.spy(physics, 'addComponent');
+      sinon.spy(physics, 'removeComponent');
       el.setAttribute('velocity', '');
       el.addEventListener('loaded', function () {
         component = el.components.velocity;
@@ -55,17 +54,17 @@ suite('velocity', function () {
     });
 
     teardown(function () {
-      physics.addBehavior.restore();
-      physics.removeBehavior.restore();
+      physics.addComponent.restore();
+      physics.removeComponent.restore();
     });
 
     test('registers with the physics system', function () {
-      expect(physics.addBehavior).to.have.been.calledWith(component, physics.Phase.RENDER);
+      expect(physics.addComponent).to.have.been.calledWith(component);
     });
 
     test('unregisters with the physics system', function () {
       el.removeAttribute('velocity');
-      expect(physics.removeBehavior).to.have.been.calledWith(component, physics.Phase.RENDER);
+      expect(physics.removeComponent).to.have.been.calledWith(component);
     });
 
     test('defaults to 0 0 0', function () {
@@ -77,7 +76,7 @@ suite('velocity', function () {
       el.setAttribute('velocity', {x: 1, y: 2, z: 3});
       component.tick(100, 0.1);
       expect(el.getAttribute('position')).to.shallowDeepEqual({x: 0, y: 0, z: 0});
-      component.step(100, 0.1 /* overridden by maxInterval */);
+      component.updateRender(100, 0.1 /* overridden by maxInterval */);
       var position = el.getAttribute('position');
       expect(position.x).to.be.closeTo(0.00005, EPS);
       expect(position.y).to.be.closeTo(0.00010, EPS);

--- a/tests/physics/body.test.js
+++ b/tests/physics/body.test.js
@@ -12,9 +12,8 @@ suite('body', function () {
 
   var body = {type: 'CANNON.Body'},
       physics = {
-        removeBehavior: sinon.spy(),
-        removeBody: sinon.spy(),
-        Phase: {SIMULATE: 0, RENDER: 1}
+        removeComponent: sinon.spy(),
+        removeBody: sinon.spy()
       };
 
   setup(function (done) {
@@ -29,7 +28,7 @@ suite('body', function () {
   });
 
   teardown(function () {
-    physics.removeBehavior.reset();
+    physics.removeComponent.reset();
     physics.removeBody.reset();
   });
 
@@ -64,7 +63,7 @@ suite('body', function () {
       component.system = physics;
       component.body = el.body = body;
       component.pause();
-      expect(physics.removeBehavior).to.have.been.calledWith(component, physics.Phase.SIMULATE);
+      expect(physics.removeComponent).to.have.been.calledWith(component);
       expect(physics.removeBody).to.have.been.calledWith(body);
     });
   });


### PR DESCRIPTION
So when trying to use aframe-extras/kinematic-body I realised there was a bug whereby you could walk through some objects (particularly spheres, cylinders, and low height boxes) by continuing to push against them.

Inspecting the source revealed that the physics syncing was a frame behind: The `kinematic-body` updates the physics body with `step` _after_ the simulation update completes, meaning there is always an extra frame of movement, due to `velocity`, before previous contacts are handled.

This pull request changes the behaviour/step system and replaces the single `step` function with 3 functions, allowing physics components to perform updates, before _and_ after the physics update (as well as before render for when/if physics updating is separated from rendering).

The following things have changed:

The `addBehavior`/`removeBehavior` functions have been removed, as has the concept of update phases.

Instead `addComponent`/`removeComponent` functions have been added, which take only a single argument - the component being installed. The update methods of the component will be scheduled, depending on which are present.

The single `step` method has been removed, and replaced with 3 optional methods:

* `updateBefore`: If present, this function will be called after all other components have `tick`ed, and immediately before the physics system performed its updates, allowing you to perform last moment syncing to the physics state.

* `updateAfter`: If present, this function will be called after the physics system has performed its updates (this executes when `step` did, when installed in the SIMULATE phase)

* `updateRender`: If present, this function will be called before render (this executes when `step` did, when installed in the RENDER phase)

This make it a lot easier to ensure things are properly synced with the physics system.

I've also have an aframe-extras PR which pairs with this one.

Cheers