### PR TITLE
Add ability to change mass on dynamic-body

### DIFF
--- a/src/components/body/body.js
+++ b/src/components/body/body.js
@@ -43,7 +43,8 @@ module.exports = {
       position: new CANNON.Vec3(pos.x, pos.y, pos.z),
       quaternion: new CANNON.Quaternion(quat.x, quat.y, quat.z, quat.w),
       linearDamping: data.linearDamping,
-      angularDamping: data.angularDamping
+      angularDamping: data.angularDamping,
+      type: data.bodyType
     });
 
     // Matrix World must be updated at root level, if scale is to be applied – updateMatrixWorld()

--- a/src/components/body/dynamic-body.js
+++ b/src/components/body/dynamic-body.js
@@ -11,7 +11,8 @@ var DynamicBody = AFRAME.utils.extend({}, Body, {
   schema: AFRAME.utils.extend({}, Body.schema, {
     mass:           { default: 5 },
     linearDamping:  { default: 0.01 },
-    angularDamping: { default: 0.01 }
+    angularDamping: { default: 0.01 },
+    bodyType: {default: 1}
   }),
 
   step: function () {
@@ -28,7 +29,6 @@ var DynamicBody = AFRAME.utils.extend({}, Body, {
 
   updateMass: function(mass) {
     this.body.mass = mass;
-    this.body.type = CANNON.Body.DYNAMIC;
     this.body.updateMassProperties();
   }
 });

--- a/src/components/body/dynamic-body.js
+++ b/src/components/body/dynamic-body.js
@@ -15,10 +15,22 @@ var DynamicBody = AFRAME.utils.extend({}, Body, {
   }),
 
   step: function () {
-    this.syncFromPhysics();
+    if (this.el.body.mass !== 0)
+      this.syncFromPhysics();
   },
 
-  afterStep: null
+  beforeStep: function() {
+    if (this.el.body.mass === 0)
+      this.syncToPhysics();
+  },
+
+  afterStep: null,
+
+  updateMass: function(mass) {
+    this.body.mass = mass;
+    this.body.type = CANNON.Body.DYNAMIC;
+    this.body.updateMassProperties();
+  }
 });
 
 module.exports = AFRAME.registerComponent('dynamic-body', DynamicBody);

--- a/src/components/body/static-body.js
+++ b/src/components/body/static-body.js
@@ -7,6 +7,10 @@ var Body = require('./body');
  * other objects may collide with it.
  */
 var StaticBody = AFRAME.utils.extend({}, Body, {
+  schema: AFRAME.utils.extend({}, Body.schema, {
+    bodyType: {default: 2}
+  }),
+
   beforeStep: function () {
     this.syncToPhysics();
   }


### PR DESCRIPTION
Not sure if this is the best/correct way to go about this (so please let me know if there's a different approach you'd prefer), but I'm in need of a way to switch a dynamic-body to static and vice-versa. Afaict, Cannon.js really only differentiates the two by whether the mass is non-zero or not. It is slightly complicated by the need to call updateMassProperties() when you change the mass as well.
So I modified the dynamic-body component with a method that allows you to update the mass and call updateMassProperties automatically. Also, I added bodyType into the schema, because if you create a dynamic-body with 0 mass, it will default to a static body type and remain so even if you change the mass later.