### PR TITLE
Fix `static-body=""` intializing a dynamic body

### DIFF
--- a/src/components/body/body.js
+++ b/src/components/body/body.js
@@ -130,7 +130,7 @@ var Body = {
 
     var data = this.data;
 
-    if (data.type !== prevData.type) {
+    if (prevData.type != undefined && data.type !== prevData.type) {
       console.warn('CANNON.Body type cannot be changed after instantiation');
     }
 

--- a/src/components/body/static-body.js
+++ b/src/components/body/static-body.js
@@ -9,7 +9,8 @@ var Body = require('./body');
 var StaticBody = AFRAME.utils.extend({}, Body.definition);
 
 StaticBody.schema = AFRAME.utils.extend({}, Body.definition.schema, {
-  type: {default: 'static', oneOf: ['static', 'dynamic']}
+  type: {default: 'static', oneOf: ['static', 'dynamic']},
+  mass: {default: 0}
 });
 
 module.exports = AFRAME.registerComponent('static-body', StaticBody);


### PR DESCRIPTION
With the default mass of 5 being inherited by `static-body`, the initial `update`  ([here](https://github.com/wmurphyrd/aframe-physics-system/blob/c667a90445be439fa2b9bc5f87c17b5fef7a9ffe/src/components/body/body.js#L137)) will convert a `static-body` without a specified mass to a dynamic body (on the cannon side) on current master. 

Also avoid the type change warning being printed during initialization