### PR TITLE
Fix rotations for debug wireframes

### DIFF
--- a/src/components/body/body.js
+++ b/src/components/body/body.js
@@ -236,7 +236,6 @@ var Body = {
       }
 
       if (orientation) {
-        orientation.inverse(orientation);
         wireframe.quaternion.copy(orientation);
       }
 

--- a/src/components/shape/shape.js
+++ b/src/components/shape/shape.js
@@ -10,7 +10,7 @@ var Shape = {
     radius: {type: 'number', default: 1, if: {shape: ['sphere']}},
 
     // box
-    halfExtents: {type: 'vec3', default: {x: 1, y: 1, z: 1}, if: {shape: ['box']}},
+    halfExtents: {type: 'vec3', default: {x: 0.5, y: 0.5, z: 0.5}, if: {shape: ['box']}},
     
     // cylinder
     radiusTop: {type: 'number', default: 1, if: {shape: ['cylinder']}},


### PR DESCRIPTION
Fix orientation of wireframe not lining up with orientation of shape. Also, change the halfExtents default so that it matches the default shape of a box.