### PR TITLE
Allow updating body.type

### DIFF
--- a/src/components/body/body.js
+++ b/src/components/body/body.js
@@ -171,8 +171,8 @@ var Body = {
 
     var data = this.data;
 
-    if (prevData.type != undefined && data.type !== prevData.type) {
-      console.warn('CANNON.Body type cannot be changed after instantiation');
+    if (prevData.type != undefined && data.type != prevData.type) {
+      this.body.type = data.type === 'dynamic' ? CANNON.Body.DYNAMIC : CANNON.Body.STATIC;
     }
 
     this.body.mass = data.mass || 0;


### PR DESCRIPTION
@wmurphyrd let me know that this should work fine. In fact, it can be preferable because if you change the type to static, a bunch of calculations don't get run on the body in Cannon, that otherwise would even if you change the mass to 0. Seems to work fine in Hubs.