### PR TITLE
Add "updateCannonScale" method to body component

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "browserify": "^14.3.0",
     "budo": "^10.0.3",
-    "cannon": "https://github.com/mozillareality/cannon.js#resize-cylinder",
+    "cannon": "github:donmccurdy/cannon.js#v0.6.2-dev1",
     "three-to-cannon": "^1.3.0",
     "webworkify": "^1.4.0"
   },

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "browserify": "^14.3.0",
     "budo": "^10.0.3",
-    "cannon": "github:donmccurdy/cannon.js#v0.6.2-dev1",
+    "cannon": "https://github.com/mozillareality/cannon.js#resize-cylinder",
     "three-to-cannon": "^1.3.0",
     "webworkify": "^1.4.0"
   },

--- a/src/components/body/body.js
+++ b/src/components/body/body.js
@@ -147,28 +147,29 @@ var Body = {
       if (!shape) continue;
       const shapeType = shape.data.shape;
       switch (shapeType){
-         case "sphere":
-           cannonShape.radius = shape.data.radius * scale.x;
-           cannonShape.updateBoundingSphereRadius();
-           break;
-         case "box":
-           const cannonHalfExtents = cannonShape.halfExtents;
-           const halfExtents = shape.data.halfExtents;
-           cannonHalfExtents.set(
-             halfExtents.x * scale.x,
-             halfExtents.y * scale.y,
-             halfExtents.z * scale.z
-           );
-           cannonShape.updateConvexPolyhedronRepresentation();
-           break;
-         case "cylinder":
-           // TODO
-         default:
-           if (!this.didIssueResizeWarning){
-             this.didIssueResizeWarning = true;
-             console.warn("Cannot resize shape of type: ", shapeType);
-           }
-           break;
+        case "sphere":
+          cannonShape.radius = shape.data.radius * scale.x;
+          cannonShape.updateBoundingSphereRadius();
+          break;
+        case "box":
+          const cannonHalfExtents = cannonShape.halfExtents;
+          const halfExtents = shape.data.halfExtents;
+          cannonHalfExtents.set(
+            halfExtents.x * scale.x,
+            halfExtents.y * scale.y,
+            halfExtents.z * scale.z
+          );
+          cannonShape.updateConvexPolyhedronRepresentation();
+          break;
+        case "cylinder":
+          cannonShape.resize(shape.data.radiusTop * scale.x, shape.data.radiusBottom*scale.x, shape.data.height*scale.y);
+          break;
+        default:
+          if (!this.didIssueResizeWarning){
+            this.didIssueResizeWarning = true;
+            console.warn("Cannot resize shape of type: ", shapeType);
+          }
+          break;
       }
       const cannonOffset = cannonBody.shapeOffsets[i];
       const offset = shape.data.offset;

--- a/src/components/body/body.js
+++ b/src/components/body/body.js
@@ -147,28 +147,28 @@ var Body = {
       if (!shape) continue;
       const shapeType = shape.data.shape;
       switch (shapeType){
-      case "sphere":
-        cannonShape.radius = shape.data.radius * scale.x;
-        cannonShape.updateBoundingSphereRadius();
-        break;
-      case "box":
-        const cannonHalfExtents = cannonShape.halfExtents;
-        const halfExtents = shape.data.halfExtents;
-        cannonHalfExtents.set(
-          halfExtents.x * scale.x,
-          halfExtents.y * scale.y,
-          halfExtents.z * scale.z
-        );
-        cannonShape.updateConvexPolyhedronRepresentation();
-        break;
-      case "cylinder":
-        // TODO
-      default:
-        if (!this.didIssueResizeWarning){
-          this.didIssueResizeWarning = true;
-          console.warn("Cannot resize shape of type: ", shapeType);
-        }
-        break;
+         case "sphere":
+           cannonShape.radius = shape.data.radius * scale.x;
+           cannonShape.updateBoundingSphereRadius();
+           break;
+         case "box":
+           const cannonHalfExtents = cannonShape.halfExtents;
+           const halfExtents = shape.data.halfExtents;
+           cannonHalfExtents.set(
+             halfExtents.x * scale.x,
+             halfExtents.y * scale.y,
+             halfExtents.z * scale.z
+           );
+           cannonShape.updateConvexPolyhedronRepresentation();
+           break;
+         case "cylinder":
+           // TODO
+         default:
+           if (!this.didIssueResizeWarning){
+             this.didIssueResizeWarning = true;
+             console.warn("Cannot resize shape of type: ", shapeType);
+           }
+           break;
       }
       const cannonOffset = cannonBody.shapeOffsets[i];
       const offset = shape.data.offset;

--- a/src/components/body/body.js
+++ b/src/components/body/body.js
@@ -3,21 +3,6 @@ var CANNON = require('cannon'),
 
 require('../../../lib/CANNON-shape2mesh');
 
-function almostEquals(u,v, eps){
-  return Math.abs(u.x-v.x) < eps && Math.abs(u.y-v.y) < eps && Math.abs(u.z-v.z) < eps;
-};
-
-function debounce(fn, delay){
-  let timer = null;
-  return function(){
-    const args = arguments;
-    clearTimeout(timer);
-    timer = setTimeout(()=>{
-      fn.apply(this, args);
-    }, delay);
-  };
-}
-
 var Body = {
   dependencies: ['velocity'],
 
@@ -28,8 +13,7 @@ var Body = {
     shape: {default: 'auto', oneOf: ['auto', 'box', 'cylinder', 'sphere', 'hull', 'mesh', 'none']},
     cylinderAxis: {default: 'y', oneOf: ['x', 'y', 'z']},
     sphereRadius: {default: NaN},
-    type: {default: 'dynamic', oneOf: ['static', 'dynamic']},
-    monitorScale: {default: 'false'}
+    type: {default: 'dynamic', oneOf: ['static', 'dynamic']}
   },
 
   /**
@@ -45,11 +29,8 @@ var Body = {
       this.el.sceneEl.addEventListener('loaded', this.initBody.bind(this));
     }
 
-    this.prevScale = this.el.object3D.scale.clone();
-    this.prevUsedScale = this.el.object3D.scale.clone();
-    this.shapeWarned = false;
-    this.scaleBy = new CANNON.Vec3(1,1,1);
-    this.scaleBody = debounce(this.scaleBody.bind(this), 500);
+    this.didIssueResizeWarning = false;
+    this.worldScale = new THREE.Vector3();
   },
 
   /**
@@ -153,38 +134,48 @@ var Body = {
       this.createWireframe(this.body);
       this.shouldUpdateWireframe = false;
     }
-
-    if (this.data.monitorScale){
-      const scale = this.el.object3D.scale;
-      if (!almostEquals(scale,this.prevScale, 0.001)){
-        this.scaleBody(scale);
-      }
-      this.prevScale.copy(scale);
-    }
   },
 
-  scaleBody: function(scale, foo){
-    this.scaleBy.set(scale.x/this.prevUsedScale.x, scale.y/this.prevUsedScale.y, scale.z/this.prevUsedScale.z);
-    for (let i=0; i<this.body.shapes.length; i++){
-      const shape = this.body.shapes[i];
-      if (shape.halfExtents){
-        shape.halfExtents.set(shape.halfExtents.x*this.scaleBy.x,
-                              shape.halfExtents.y*this.scaleBy.y,
-                              shape.halfExtents.y*this.scaleBy.y);
-        shape.updateConvexPolyhedronRepresentation();
-      } else if (shape.radius){
-        shape.radius *= this.scaleBy.x; // TODO: Support the case where you want to squish an object on one axis, but keep its spherical collider.
-        shape.updateBoundingSphereRadius();
-      } else if (!this.shapeWarned){
-        console.warn("unable to stretch physics body: unsupported shape", this.body, shape);
-        this.shapeWarned = true;
+  updateCannonScale: function(){
+    this.el.object3D.getWorldScale(this.worldScale);
+    const scale = this.worldScale;
+    const cannonBody = this.body;
+
+    for (var i=0; i<cannonBody.shapes.length; i++){
+      const cannonShape = cannonBody.shapes[i];
+      const shape = cannonShape.component;
+      if (!shape) continue;
+      const shapeType = shape.data.shape;
+      switch (shapeType){
+      case "sphere":
+        cannonShape.radius = shape.data.radius * scale.x;
+        cannonShape.updateBoundingSphereRadius();
+        break;
+      case "box":
+        const cannonHalfExtents = cannonShape.halfExtents;
+        const halfExtents = shape.data.halfExtents;
+        cannonHalfExtents.set(
+          halfExtents.x * scale.x,
+          halfExtents.y * scale.y,
+          halfExtents.z * scale.z
+        );
+        cannonShape.updateConvexPolyhedronRepresentation();
+        break;
+      case "cylinder":
+        // TODO
+      default:
+        if (!this.didIssueResizeWarning){
+          this.didIssueResizeWarning = true;
+          console.warn("Cannot resize shape of type: ", shapeType);
+        }
+        break;
       }
-      const offset = this.body.shapeOffsets[i];
-      offset.set(offset.x*this.scaleBy.x, offset.y*this.scaleBy.y, offset.z*this.scaleBy.z);
+      const cannonOffset = cannonBody.shapeOffsets[i];
+      const offset = shape.data.offset;
+      cannonOffset.set(offset.x*scale.x, offset.y*scale.y, offset.z*scale.z);
     }
-    this.body.updateBoundingRadius();
-    this.body.aabbNeedsUpdate = true;
-    this.prevUsedScale.copy(scale);
+    cannonBody.updateBoundingRadius();
+    cannonBody.aabbNeedsUpdate = true;
     this.shouldUpdateWireframe = this.system.debug;
   },
 

--- a/src/components/body/body.js
+++ b/src/components/body/body.js
@@ -185,6 +185,7 @@ var Body = {
     this.body.updateBoundingRadius();
     this.body.aabbNeedsUpdate = true;
     this.prevUsedScale.copy(scale);
+    this.shouldUpdateWireframe = this.system.debug;
   },
 
   /**

--- a/src/components/body/body.js
+++ b/src/components/body/body.js
@@ -161,9 +161,10 @@ var Body = {
           );
           cannonShape.updateConvexPolyhedronRepresentation();
           break;
-        case "cylinder":
-          cannonShape.resize(shape.data.radiusTop * scale.x, shape.data.radiusBottom*scale.x, shape.data.height*scale.y);
-          break;
+        //case "cylinder":
+          // https://github.com/MozillaReality/cannon.js/commit/b401ccbec3b9996e31d6ad060028065a432fcff7
+          // cannonShape.resize(shape.data.radiusTop * scale.x, shape.data.radiusBottom*scale.x, shape.data.height*scale.y);
+          // break;
         default:
           if (!this.didIssueResizeWarning){
             this.didIssueResizeWarning = true;

--- a/src/components/math/velocity.js
+++ b/src/components/math/velocity.js
@@ -6,6 +6,9 @@ module.exports = AFRAME.registerComponent('velocity', {
 
   init: function () {
     this.system = this.el.sceneEl.systems.physics;
+    this.defaultVelocity = {x: 0, y: 0, z: 0};
+    this.defaultPosition = {x: 0, y: 0, z: 0};
+    this.position = {x: 0, y: 0, z: 0};
 
     if (this.system) {
       this.system.addComponent(this);
@@ -29,16 +32,16 @@ module.exports = AFRAME.registerComponent('velocity', {
 
     var physics = this.el.sceneEl.systems.physics || {data: {maxInterval: 1 / 60}},
 
-        // TODO - There's definitely a bug with getComputedAttribute and el.data.
-        velocity = this.el.getAttribute('velocity') || {x: 0, y: 0, z: 0},
-        position = this.el.getAttribute('position') || {x: 0, y: 0, z: 0};
+    // TODO - There's definitely a bug with getComputedAttribute and el.data.
+    velocity = this.el.getAttribute('velocity') || this.defaultVelocity,
+    position = this.el.getAttribute('position') || this.defaultPosition;
 
     dt = Math.min(dt, physics.data.maxInterval * 1000);
 
-    this.el.setAttribute('position', {
-      x: position.x + velocity.x * dt / 1000,
-      y: position.y + velocity.y * dt / 1000,
-      z: position.z + velocity.z * dt / 1000
-    });
+    this.position.x = position.x + velocity.x * dt / 1000;
+    this.position.y = position.y + velocity.y * dt / 1000;
+    this.position.z = position.z + velocity.z * dt / 1000;
+
+    this.el.setAttribute('position', this.position);
   }
 });

--- a/src/components/shape/shape.js
+++ b/src/components/shape/shape.js
@@ -11,7 +11,7 @@ var Shape = {
 
     // box
     halfExtents: {type: 'vec3', default: {x: 0.5, y: 0.5, z: 0.5}, if: {shape: ['box']}},
-    
+
     // cylinder
     radiusTop: {type: 'number', default: 1, if: {shape: ['cylinder']}},
     radiusBottom: {type: 'number', default: 1, if: {shape: ['cylinder']}},
@@ -50,8 +50,8 @@ var Shape = {
 
     if (data.hasOwnProperty('offset')) {
       offset = new CANNON.Vec3(
-        data.offset.x * scale.x, 
-        data.offset.y * scale.y, 
+        data.offset.x * scale.x,
+        data.offset.y * scale.y,
         data.offset.z * scale.z
       );
     }
@@ -67,17 +67,17 @@ var Shape = {
         break;
       case 'box':
         var halfExtents = new CANNON.Vec3(
-          data.halfExtents.x * scale.x, 
-          data.halfExtents.y * scale.y, 
+          data.halfExtents.x * scale.x,
+          data.halfExtents.y * scale.y,
           data.halfExtents.z * scale.z
         );
         shape = new CANNON.Box(halfExtents);
         break;
       case 'cylinder':
         shape = new CANNON.Cylinder(
-          data.radiusTop * scale.x, 
-          data.radiusBottom * scale.x, 
-          data.height * scale.y, 
+          data.radiusTop * scale.x,
+          data.radiusBottom * scale.x,
+          data.height * scale.y,
           data.numSegments
         );
 
@@ -90,6 +90,7 @@ var Shape = {
           console.warn(data.shape + ' shape not supported');
         return;
     }
+    shape.component = this;
 
     if (this.bodyEl.body) {
       this.bodyEl.components[bodyType].addShape(shape, offset, orientation);


### PR DESCRIPTION
Calling this method will update the scale of the shapes in the underlying Cannon body, for those shapes with shape components.
(I did not implement the update for those shapes that are attached by a shape component, because I do not know those shapes' halfExtents / radius in the local space of this entity.)