### PR TITLE
Don't take browserify and budo as first-class deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,8 +37,6 @@
   },
   "homepage": "https://github.com/donmccurdy/aframe-physics-system#readme",
   "dependencies": {
-    "browserify": "^14.3.0",
-    "budo": "^10.0.3",
     "cannon": "github:donmccurdy/cannon.js#v0.6.2-dev1",
     "three-to-cannon": "^1.3.0",
     "webworkify": "^1.4.0"


### PR DESCRIPTION
Perhaps I'm misunderstanding something, but it seems to me that these are already in the `devDependencies`, and it doesn't seem to me like they ought to be in the ordinary dependencies.

(This can matter to upstream packages, since it means that upstream packages will have to take the time to install these dependencies even if they use a different build toolchain that doesn't need them.)