### PR TITLE
Replace setAttribute call in velocity.js

### DIFF
--- a/src/components/math/velocity.js
+++ b/src/components/math/velocity.js
@@ -6,9 +6,7 @@ module.exports = AFRAME.registerComponent('velocity', {
 
   init: function () {
     this.system = this.el.sceneEl.systems.physics;
-    this.defaultVelocity = {x: 0, y: 0, z: 0};
-    this.defaultPosition = {x: 0, y: 0, z: 0};
-
+    
     if (this.system) {
       this.system.addComponent(this);
     }
@@ -32,8 +30,8 @@ module.exports = AFRAME.registerComponent('velocity', {
     var physics = this.el.sceneEl.systems.physics || {data: {maxInterval: 1 / 60}},
 
     // TODO - There's definitely a bug with getComputedAttribute and el.data.
-    velocity = this.el.getAttribute('velocity') || this.defaultVelocity,
-    position = this.el.object3D.position || this.defaultPosition;
+    velocity = this.el.getAttribute('velocity') || {x: 0, y: 0, z: 0},
+    position = this.el.object3D.position || {x: 0, y: 0, z: 0};
 
     dt = Math.min(dt, physics.data.maxInterval * 1000);
 

--- a/src/components/math/velocity.js
+++ b/src/components/math/velocity.js
@@ -6,6 +6,8 @@ module.exports = AFRAME.registerComponent('velocity', {
 
   init: function () {
     this.system = this.el.sceneEl.systems.physics;
+    this.defaultVelocity = {x: 0, y: 0, z: 0};
+    this.defaultPosition = {x: 0, y: 0, z: 0};
 
     if (this.system) {
       this.system.addComponent(this);
@@ -29,16 +31,16 @@ module.exports = AFRAME.registerComponent('velocity', {
 
     var physics = this.el.sceneEl.systems.physics || {data: {maxInterval: 1 / 60}},
 
-        // TODO - There's definitely a bug with getComputedAttribute and el.data.
-        velocity = this.el.getAttribute('velocity') || {x: 0, y: 0, z: 0},
-        position = this.el.getAttribute('position') || {x: 0, y: 0, z: 0};
+    // TODO - There's definitely a bug with getComputedAttribute and el.data.
+    velocity = this.el.getAttribute('velocity') || this.defaultVelocity,
+    position = this.el.object3D.position || this.defaultPosition;
 
     dt = Math.min(dt, physics.data.maxInterval * 1000);
 
-    this.el.setAttribute('position', {
-      x: position.x + velocity.x * dt / 1000,
-      y: position.y + velocity.y * dt / 1000,
-      z: position.z + velocity.z * dt / 1000
-    });
+    this.el.object3D.position.set(
+      position.x + velocity.x * dt / 1000,
+      position.y + velocity.y * dt / 1000,
+      position.z + velocity.z * dt / 1000
+    );
   }
 });

--- a/src/components/math/velocity.js
+++ b/src/components/math/velocity.js
@@ -6,7 +6,7 @@ module.exports = AFRAME.registerComponent('velocity', {
 
   init: function () {
     this.system = this.el.sceneEl.systems.physics;
-    
+
     if (this.system) {
       this.system.addComponent(this);
     }


### PR DESCRIPTION
don't use get/setAttribute; read/set object3D.posiiton directly to avoid overhead of calling setAttribute.