### PR TITLE
Ammo Heightfields

### DIFF
--- a/AmmoDriver.md
+++ b/AmmoDriver.md
@@ -215,17 +215,20 @@ See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators
 
 Any entity with an `ammo-body` component can also have 1 or more `ammo-shape` components. The `ammo-shape` component is what defines the collision shape of the entity. `ammo-shape` components can be added and removed at any time. The actual work of generating a `btCollisionShape` is done via an external library, [Three-to-Ammo](https://github.com/infinitelee/three-to-ammo).
 
-| Property      | Dependencies | Default | Description |
-| ------------- | --------------------------------------------------------- | ----------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
-| type          | —                                                         | `hull`                        | Options: `box`, `cylinder`, `sphere`, `capsule`, `cone`, `hull`, `hacd`, `vhacd`, `mesh`. see [Shape Types](#shape-types).    |
-| fit           | —                                                         | `all`                         | Options: `all`, `manual`. Use `manual` if defining `halfExtents` or `sphereRadius` below. See [Shape Fit](#shape-fit).        |
-| halfExtents   | `fit: manual` and `type: box, cylinder, capsule, cone`    | `1 1 1`                       | Set the halfExtents to use.                                                                                                   |
-| minHalfExtent | `fit: all` and `type: box, cylinder, capsule, cone`       | `0`                           | The minimum value for any axis of the halfExtents.                                                                            |
-| maxHalfExtent | `fit: all` and `type: box, cylinder, capsule, cone`       | `Number.POSITIVE_INFINITY`    | The maximum value for any axis of the halfExtents.                                                                            |
-| sphereRadius  | `fit: manual` and `type: sphere`                          | `NaN`                         | Set the radius for spheres.                                                                                                   |
-| cylinderAxis  | —                                                         | `y`                           | Options: `x`, `y`, `z`. Override default axis for `cylinder`, `capsule`, and `cone` types.                                    |
-| margin        | —                                                         | `0.01`                        | The amount of 'padding' to add around the shape. Larger values have better performance but reduce collision shape precision.  |
-| offset        | —                                                         | `0 0 0`                       | Where to position the shape relative to the origin of the entity.                                                             |
+| Property            | Dependencies                                              | Default                       | Description                                                                                                                               |
+| ------------------- | --------------------------------------------------------- | ----------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| type                | —                                                         | `hull`                        | Options: `box`, `cylinder`, `sphere`, `capsule`, `cone`, `hull`, `hacd`, `vhacd`, `mesh`, `heightfield`. see [Shape Types](#shape-types). |
+| fit                 | —                                                         | `all`                         | Options: `all`, `manual`. Use `manual` if defining `halfExtents` or `sphereRadius` below. See [Shape Fit](#shape-fit).                    |
+| halfExtents         | `fit: manual` and `type: box, cylinder, capsule, cone`    | `1 1 1`                       | Set the halfExtents to use.                                                                                                               |
+| minHalfExtent       | `fit: all` and `type: box, cylinder, capsule, cone`       | `0`                           | The minimum value for any axis of the halfExtents.                                                                                        |
+| maxHalfExtent       | `fit: all` and `type: box, cylinder, capsule, cone`       | `Number.POSITIVE_INFINITY`    | The maximum value for any axis of the halfExtents.                                                                                        |
+| sphereRadius        | `fit: manual` and `type: sphere`                          | `NaN`                         | Set the radius for spheres.                                                                                                               |
+| cylinderAxis        | —                                                         | `y`                           | Options: `x`, `y`, `z`. Override default axis for `cylinder`, `capsule`, and `cone` types.                                                |
+| margin              | —                                                         | `0.01`                        | The amount of 'padding' to add around the shape. Larger values have better performance but reduce collision shape precision.              |
+| offset              | —                                                         | `0 0 0`                       | Where to position the shape relative to the origin of the entity.                                                                         |
+| heightfieldData     | `fit: manual` and `type: heightfield`                     | `[]`                          | An array of arrays of float values that represent a height at a fixed interval `heightfieldDistance`                                      |
+| heightfieldDistance | `fit: manual` and `type: heightfield`                     | `1`                           | The distance between each height value in both the x and z direction in `heightfieldData`                                                 |
+| includeInvisible    | `fit: all`                                                | `false`                       | Should invisible meshes be included when using `fit: all`                                                                                 |
 
 #### Shape Types
 
@@ -241,6 +244,7 @@ Any entity with an `ammo-body` component can also have 1 or more `ammo-shape` co
 - **Mesh** (`mesh`) – Creates a 1:1 concave collision shape with the triangles of the meshes of the entity. May only be used on `static` bodies. This is the least performant shape, however they can work very well for static environments if the following is observed:
   - Avoid using meshes with very high triangle density relative to size of convex objects (primitives and hulls) colliding with the mesh. E.g. avoid meshes where an object could collide with dozens or more triangles in a single spot.
   - Avoid very high poly meshes in general and use mesh decimation (simplification) if possible.
+- **Heightfield** (`heightfield`) – Similar to a mesh shape, but you must provide an array of heights and the distance between those values. E.g. `heightfieldData: [[0, 0, 0], [0, 1, 0], [0, 0, 0]]` and `heightfieldDistance: 1` will create a 3x3 meter heightfield with a height of 0 except for the center with a height of 1.
 
 #### Shape Fit
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9512,7 +9512,7 @@
       }
     },
     "three-to-ammo": {
-      "version": "github:infinitelee/three-to-ammo#11830faeec9821b4a88d5e1fd130906e16174170",
+      "version": "github:infinitelee/three-to-ammo#5b0587c660080822049f1ed87e13ba15f0e74d2f",
       "from": "github:infinitelee/three-to-ammo"
     },
     "three-to-cannon": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "homepage": "https://github.com/donmccurdy/aframe-physics-system#readme",
   "dependencies": {
     "ammo-debug-drawer": "github:infinitelee/ammo-debug-drawer",
-    "cannon": "github:donmccurdy/cannon.js#v0.6.2-dev1",
+    "cannon": "github:donmccurdy/cannon.js#022e8ba53fa83abf0ad8a0e4fd08623123838a17",
     "three-to-ammo": "github:infinitelee/three-to-ammo",
     "three-to-cannon": "^1.3.0",
     "webworkify": "^1.4.0"

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "homepage": "https://github.com/donmccurdy/aframe-physics-system#readme",
   "dependencies": {
     "ammo-debug-drawer": "github:infinitelee/ammo-debug-drawer",
-    "cannon": "github:donmccurdy/cannon.js#022e8ba53fa83abf0ad8a0e4fd08623123838a17",
+    "cannon": "github:donmccurdy/cannon.js#v0.6.2-dev1",
     "three-to-ammo": "github:infinitelee/three-to-ammo",
     "three-to-cannon": "^1.3.0",
     "webworkify": "^1.4.0"

--- a/src/components/shape/ammo-shape.js
+++ b/src/components/shape/ammo-shape.js
@@ -30,7 +30,6 @@ var AmmoShape = {
     margin: { default: 0.01 },
     offset: { type: "vec3", default: { x: 0, y: 0, z: 0 } },
     orientation: { type: "vec4", default: { x: 0, y: 0, z: 0, w: 1 } },
-    heightfieldDistance: { default: 0.1 },
     heightfieldData: { default: [] },
     heightfieldDistance: { default: 1 },
     includeInvisible: { default: false }

--- a/src/components/shape/ammo-shape.js
+++ b/src/components/shape/ammo-shape.js
@@ -31,7 +31,9 @@ var AmmoShape = {
     offset: { type: "vec3", default: { x: 0, y: 0, z: 0 } },
     orientation: { type: "vec4", default: { x: 0, y: 0, z: 0, w: 1 } },
     heightfieldDistance: { default: 0.1 },
-    heightfieldData: { default: [] }
+    heightfieldData: { default: [] },
+    heightfieldDistance: { default: 1 },
+    includeInvisible: { default: false }
   },
 
   multiple: true,

--- a/src/components/shape/ammo-shape.js
+++ b/src/components/shape/ammo-shape.js
@@ -17,7 +17,8 @@ var AmmoShape = {
         SHAPE.HULL,
         SHAPE.HACD,
         SHAPE.VHACD,
-        SHAPE.MESH
+        SHAPE.MESH,
+        SHAPE.HEIGHTFIELD
       ]
     },
     fit: { default: FIT.ALL, oneOf: [FIT.ALL, FIT.MANUAL] },
@@ -28,7 +29,9 @@ var AmmoShape = {
     cylinderAxis: { default: "y", oneOf: ["x", "y", "z"] },
     margin: { default: 0.01 },
     offset: { type: "vec3", default: { x: 0, y: 0, z: 0 } },
-    orientation: { type: "vec4", default: { x: 0, y: 0, z: 0, w: 1 } }
+    orientation: { type: "vec4", default: { x: 0, y: 0, z: 0, w: 1 } },
+    heightfieldDistance: { default: 0.1 },
+    heightfieldData: { default: [] }
   },
 
   multiple: true,

--- a/src/constants.js
+++ b/src/constants.js
@@ -40,7 +40,8 @@ module.exports = {
     HULL: "hull",
     HACD: "hacd",
     VHACD: "vhacd",
-    MESH: "mesh"
+    MESH: "mesh",
+    HEIGHTFIELD: "heightfield"
   },
   FIT: {
     ALL: "all",


### PR DESCRIPTION
Adds support for heightfields in `ammo-shape`. Also adds a new property `includeInvisible` which will determine whether or not invisible meshes will be included with `fit: all`.