### PR TITLE
Update ammo dependency package versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -115,8 +115,9 @@
       "dev": true
     },
     "ammo-debug-drawer": {
-      "version": "github:infinitelee/ammo-debug-drawer#0b2c323ef65b4fd414235b6a5e705cfc1201c765",
-      "from": "github:infinitelee/ammo-debug-drawer"
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/ammo-debug-drawer/-/ammo-debug-drawer-0.1.0.tgz",
+      "integrity": "sha512-GIfIf748qpfg++iXFzTB1p/M7ncJK5/X2qkg7mAQm4SPyhx93PSEejSEsZiPnk8eUUwlpyPSRMPDnpITMvlJCg=="
     },
     "an-array": {
       "version": "1.0.0",
@@ -7723,8 +7724,9 @@
       }
     },
     "three-to-ammo": {
-      "version": "github:infinitelee/three-to-ammo#5b0587c660080822049f1ed87e13ba15f0e74d2f",
-      "from": "github:infinitelee/three-to-ammo"
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/three-to-ammo/-/three-to-ammo-0.1.0.tgz",
+      "integrity": "sha512-+XxlQdAlU20NHjA0As7tRUsTy9VutK6bhB+QiQx0vcET5m5t1l4/mmbXPy4aNnLnvRDWE3bepBvT8DC2OX15Jg=="
     },
     "three-to-cannon": {
       "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -37,9 +37,9 @@
   },
   "homepage": "https://github.com/donmccurdy/aframe-physics-system#readme",
   "dependencies": {
-    "ammo-debug-drawer": "github:infinitelee/ammo-debug-drawer",
+    "ammo-debug-drawer": "^0.1.0",
     "cannon": "github:donmccurdy/cannon.js#v0.6.2-dev1",
-    "three-to-ammo": "github:infinitelee/three-to-ammo",
+    "three-to-ammo": "^0.1.0",
     "three-to-cannon": "^1.3.0",
     "webworkify": "^1.4.0"
   },


### PR DESCRIPTION
`ammo-debug-drawer` and `three-to-ammo` have recently been updated with non-backwards-compatible changes. This PR just fixes the version of those in the `package.json` and `package.lock.json` files to the older, compatible versions. 